### PR TITLE
fix: wrap web_search with @tool to prevent crash on missing config

### DIFF
--- a/src/mini_opencode/tools/web/web_search.py
+++ b/src/mini_opencode/tools/web/web_search.py
@@ -1,21 +1,49 @@
 import json
 import warnings
 
+from langchain.tools import tool
+
 from mini_opencode.config import get_config_section
 
 # Suppress warnings from langchain_tavily regarding Pydantic field shadowing
 warnings.filterwarnings("ignore", category=UserWarning, module="langchain_tavily")
 from langchain_tavily import TavilySearch  # noqa: E402
 
-web_search_tool = TavilySearch(
-    name="web_search",
-    max_results=5,
-    tavily_api_key=get_config_section(
-        ["tools", "configs", "web_search", "tavily_api_key"]
-    ),
-)
+
+@tool("web_search", parse_docstring=True)
+def web_search_tool(query: str, max_results: int = 5) -> str:
+    """
+    Search the web for the given query using Tavily.
+
+    Args:
+        query: The search query to execute.
+        max_results: The maximum number of search results to return. Defaults to 5.
+
+    Returns:
+        A JSON string containing the search results, including titles, urls, and content.
+    """
+    settings = get_config_section(["tools", "configs", "web_search"])
+    if not settings:
+        raise ValueError(
+            "The `tools/configs/web_search` section in `config.yaml` is not found. "
+            "Please check your configuration file."
+        )
+
+    api_key = settings.get("api_key")
+    if not api_key:
+        raise ValueError(
+            "The `tavily_api_key` is not specified in the `tools/configs/web_search` section."
+        )
+
+    tool = TavilySearch(
+        tavily_api_key=api_key,
+        max_results=max_results,
+    )
+
+    # The tool returns a list of results, we convert it to JSON string for consistency
+    results = tool.invoke(query)
+    return json.dumps(results, ensure_ascii=False, indent=4)
+
 
 if __name__ == "__main__":
-    print(
-        json.dumps(web_search_tool.invoke("NBA Finals"), ensure_ascii=False, indent=4)
-    )
+    print(web_search_tool.invoke({"query": "NBA Finals", "max_results": 5}))


### PR DESCRIPTION
## Description

Fixed an issue where running mini-OpenCode would crash if web_search is not enabled in `config.yaml` and the Tavily API key is not set.

### Bug Fix

- **Root Cause**: The previous implementation attempted to initialize `TavilySearch` during module loading or initialization, causing the application to fail startup in environments lacking web search configuration.
- **Solution**: Wrapped the `TavilySearch` initialization logic inside the `web_search_tool` function using the `@tool` decorator.
- **Impact**: Implemented **Lazy Loading**. The Tavily client is now only initialized when the Agent actually decides to invoke the `web_search` tool. This ensures the core application starts and runs correctly even without web search configuration.

### Related Files

- `src/mini_opencode/tools/web/web_search.py`

### Testing

1. Disable `web_search` or remove `tavily_api_key` in `config.yaml`.
2. Run `mini-OpenCode`.
3. Verify that the application starts successfully without throwing configuration errors.